### PR TITLE
modify-model-input

### DIFF
--- a/board.py
+++ b/board.py
@@ -48,6 +48,8 @@ class Board:
                             {(0, BOARD_WIDTH-1): 0, (1, BOARD_WIDTH-1): 1, (0, BOARD_WIDTH-2): 2,
                              (2, BOARD_WIDTH-1): 3, (1, BOARD_WIDTH-2): 4, (0, BOARD_WIDTH-3): 5}]
 
+        self.hist_moves = []
+
 
     def check_win(self):
         """
@@ -196,7 +198,10 @@ class Board:
 
         # Update history
         self.board = np.concatenate((np.expand_dims(cur_board, axis=2), self.board[:, :, :NUM_HIST_MOVES - 1]), axis=2)
-
+        if len(self.hist_moves) == (NUM_HIST_MOVES-1)*2:
+            self.hist_moves = self.hist_moves [2:]
+        self.hist_moves.append(origin_pos)
+        self.hist_moves.append(dest_pos)
         return self.check_win()
 
     def player_progress(self, player_id):

--- a/board.py
+++ b/board.py
@@ -198,10 +198,9 @@ class Board:
 
         # Update history
         self.board = np.concatenate((np.expand_dims(cur_board, axis=2), self.board[:, :, :NUM_HIST_MOVES - 1]), axis=2)
-        if len(self.hist_moves) == (NUM_HIST_MOVES-1)*2:
-            self.hist_moves = self.hist_moves [2:]
-        self.hist_moves.append(origin_pos)
-        self.hist_moves.append(dest_pos)
+        if len(self.hist_moves) == (NUM_HIST_MOVES-1):
+            self.hist_moves = self.hist_moves [1:]
+        self.hist_moves.append((origin_pos,dest_pos))
         return self.check_win()
 
     def player_progress(self, player_id):

--- a/model.py
+++ b/model.py
@@ -81,23 +81,50 @@ class Model:
         Output:
             7 x 7 x 7. First 3 channel is player 1, next 3 channel is player 2, last channel is all 0 if player 1 is to play.
         """
+        # initialise the model input
         model_input = np.zeros((BOARD_WIDTH, BOARD_HEIGHT, NUM_HIST_MOVES * 2 + 1), dtype="uint8") # may change dtype afterwards
+        # get np array board
+        new_board = board.board
+        # get history moves
+        moves = board.hist_moves
+        # get opponent player
         op_player = PLAYER_ONE + PLAYER_TWO - cur_player
-        for channel in range(NUM_HIST_MOVES):
-            if not np.any(board[:, :, channel]): # timestep < 0
+
+        # firstly, construct the current state
+        op_layer = np.copy(new_board[:, :, 0])
+        cur_layer = np.copy(new_board[:, :, 0])
+        # construct layer for current player
+        np.putmask(cur_layer, cur_layer != cur_player, 0)
+        for checker_id, checker_pos in board.checkers_pos[cur_player].items():
+            cur_layer[checker_pos[0], checker_pos[1]] = checker_id + 1
+        # construct layer for opponent player
+        np.putmask(op_layer, op_layer != op_player, 0)
+        for checker_id, checker_pos in board.checkers_pos[op_player].items():
+            op_layer[checker_pos[0], checker_pos[1]] = checker_id + 1
+
+        model_input[:, :, 0] = np.copy(cur_layer)
+        model_input[:, :, 1] = np.copy(op_layer)
+
+        # construct the latter layers
+        moved_player = op_player
+        hist_index = len(moves) - 1
+        for channel in range(1, NUM_HIST_MOVES):
+            if not np.any(new_board[:, :, channel]): # timestep < 0
                 break
-
-            op_layer = np.copy(board[:, :, channel])
-            cur_layer = np.copy(board[:, :, channel])
-
-            np.putmask(cur_layer, cur_layer != cur_player, 0)
-            np.putmask(cur_layer, cur_layer == cur_player, 1)
-
-            np.putmask(op_layer, op_layer != op_player, 0)
-            np.putmask(op_layer, op_layer == op_player, 1)
-
-            model_input[:, :, channel * 2] = cur_layer
-            model_input[:, :, channel * 2 + 1] = op_layer
+            dist_pos = moves[hist_index]
+            orig_pos = moves[hist_index - 1]
+            if moved_player == cur_player:
+                value = cur_layer[dist_pos[0], dist_pos[1]]
+                cur_layer[dist_pos[0], dist_pos[1]] = cur_layer[orig_pos[0], orig_pos[1]]
+                cur_layer[orig_pos[0], orig_pos[1]] = value
+            else:
+                value = op_layer[dist_pos[0], dist_pos[1]]
+                op_layer[dist_pos[0], dist_pos[1]] = op_layer[orig_pos[0], orig_pos[1]]
+                op_layer[orig_pos[0], orig_pos[1]] = value
+            hist_index -= 2
+            moved_player = PLAYER_ONE + PLAYER_TWO - moved_player
+            model_input[:, :, channel * 2] = np.copy(cur_layer)
+            model_input[:, :, channel * 2 + 1] = np.copy(op_layer)
 
         if cur_player == 2: # player 2 to play
             model_input[:, :, NUM_HIST_MOVES * 2] = np.ones((BOARD_WIDTH, BOARD_HEIGHT), dtype="uint8")

--- a/model.py
+++ b/model.py
@@ -90,7 +90,7 @@ class Model:
         # get opponent player
         op_player = PLAYER_ONE + PLAYER_TWO - cur_player
 
-        # firstly, construct the current state
+        # firstly, construct the current state layers
         op_layer = np.copy(new_board[:, :, 0])
         cur_layer = np.copy(new_board[:, :, 0])
         # construct layer for current player
@@ -111,17 +111,18 @@ class Model:
         for channel in range(1, NUM_HIST_MOVES):
             if not np.any(new_board[:, :, channel]): # timestep < 0
                 break
-            dist_pos = moves[hist_index]
-            orig_pos = moves[hist_index - 1]
+            move = moves[hist_index]
+            orig_pos = move[0]
+            dest_pos = move[1]
             if moved_player == cur_player:
-                value = cur_layer[dist_pos[0], dist_pos[1]]
-                cur_layer[dist_pos[0], dist_pos[1]] = cur_layer[orig_pos[0], orig_pos[1]]
-                cur_layer[orig_pos[0], orig_pos[1]] = value
+                value = cur_layer[dest_pos]
+                cur_layer[dest_pos] = cur_layer[orig_pos]
+                cur_layer[orig_pos] = value
             else:
-                value = op_layer[dist_pos[0], dist_pos[1]]
-                op_layer[dist_pos[0], dist_pos[1]] = op_layer[orig_pos[0], orig_pos[1]]
-                op_layer[orig_pos[0], orig_pos[1]] = value
-            hist_index -= 2
+                value = op_layer[dest_pos]
+                op_layer[dest_pos] = op_layer[orig_pos]
+                op_layer[orig_pos] = value
+            hist_index -= 1
             moved_player = PLAYER_ONE + PLAYER_TWO - moved_player
             model_input[:, :, channel * 2] = np.copy(cur_layer)
             model_input[:, :, channel * 2 + 1] = np.copy(op_layer)


### PR DESCRIPTION
Mark checker ids for the model input.
Add variable history moves for class board.
**Notes:**
I only used the current board state in the model input. What I did is using the history moves and the current board states to generate the history layers. The time complexity is ok, since while generating the history states I only modify the moved checker.
I suggest we should only store the current board state rather than NUM_OF_HISTORY states in class Board.